### PR TITLE
Change error type name in TryFrom trait

### DIFF
--- a/src/serialization/v2j.rs
+++ b/src/serialization/v2j.rs
@@ -30,8 +30,8 @@ struct V2JSerialization {
 }
 
 impl TryFrom<Macaroon> for V2JSerialization {
-    type Err = MacaroonError;
-    fn try_from(macaroon: Macaroon) -> Result<Self, Self::Err> {
+    type Error = MacaroonError;
+    fn try_from(macaroon: Macaroon) -> Result<Self, Self::Error> {
         let mut serialized: V2JSerialization = V2JSerialization {
             v: 2,
             i: Some(macaroon.identifier().clone()),
@@ -76,8 +76,8 @@ impl TryFrom<Macaroon> for V2JSerialization {
 }
 
 impl TryFrom<V2JSerialization> for Macaroon {
-    type Err = MacaroonError;
-    fn try_from(ser: V2JSerialization) -> Result<Self, Self::Err> {
+    type Error = MacaroonError;
+    fn try_from(ser: V2JSerialization) -> Result<Self, Self::Error> {
         if ser.i.is_some() && ser.i64.is_some() {
             return Err(MacaroonError::DeserializationError(String::from("Found i and i64 fields")));
         }


### PR DESCRIPTION
Hi,

I was trying to use the library with `rustc 1.21.0-nightly` and I was getting the following error message:

```
error[E0437]: type `Err` is not a member of trait `TryFrom`
  --> src/serialization/v2j.rs:33:5
   |
33 |     type Err = MacaroonError;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `TryFrom`
```

Apparently the `TryFrom` trait definition has changed, [see](https://github.com/rust-lang/rust/commit/2561dcddf9e61f5c52a65f1a42641e01bfabe3e2
)

This commit changes the source code to match the new [trait definition](https://doc.rust-lang.org/core/convert/trait.TryFrom.html).