### PR TITLE
Patch to work with stable rust (1.29.0)

### DIFF
--- a/src/caveat.rs
+++ b/src/caveat.rs
@@ -91,7 +91,7 @@ impl Caveat for FirstPartyCaveat {
     }
 
     fn clone_box(&self) -> Box<Caveat> {
-        box self.clone()
+        Box::new(self.clone())
     }
 }
 
@@ -149,7 +149,7 @@ impl Caveat for ThirdPartyCaveat {
     }
 
     fn clone_box(&self) -> Box<Caveat> {
-        box self.clone()
+        Box::new(self.clone())
     }
 }
 
@@ -202,12 +202,12 @@ impl CaveatBuilder {
             return Err(MacaroonError::BadMacaroon("No identifier found"));
         }
         if self.verifier_id.is_none() && self.location.is_none() {
-            return Ok(box new_first_party(&self.id.unwrap()));
+            return Ok(Box::new(new_first_party(&self.id.unwrap())));
         }
         if self.verifier_id.is_some() && self.location.is_some() {
-            return Ok(box new_third_party(&self.id.unwrap(),
+            return Ok(Box::new(new_third_party(&self.id.unwrap(),
                                           self.verifier_id.unwrap(),
-                                          &self.location.unwrap()));
+                                          &self.location.unwrap())));
         }
         if self.verifier_id.is_none() {
             return Err(MacaroonError::BadMacaroon("Location but no verifier ID found"));
@@ -225,9 +225,9 @@ mod tests {
         let a = new_first_party("user = alice");
         let b = new_first_party("user = alice");
         let c = new_first_party("user = bob");
-        let box_a: Box<Caveat> = box a;
-        let box_b: Box<Caveat> = box b;
-        let box_c: Box<Caveat> = box c;
+        let box_a: Box<Caveat> = Box::new(a);
+        let box_b: Box<Caveat> = Box::new(b);
+        let box_c: Box<Caveat> = Box::new(c);
         assert_eq!(*box_a, *box_b);
         assert!(*box_a != *box_c);
     }
@@ -237,9 +237,9 @@ mod tests {
         let a = new_third_party("foo", b"bar".to_vec(), "foobar");
         let b = new_third_party("foo", b"bar".to_vec(), "foobar");
         let c = new_third_party("baz", b"bar".to_vec(), "foobar");
-        let box_a: Box<Caveat> = box a;
-        let box_b: Box<Caveat> = box b;
-        let box_c: Box<Caveat> = box c;
+        let box_a: Box<Caveat> = Box::new(a);
+        let box_b: Box<Caveat> = Box::new(b);
+        let box_c: Box<Caveat> = Box::new(c);
         assert_eq!(*box_a, *box_b);
         assert!(*box_a != *box_c);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ impl Macaroon {
     pub fn add_first_party_caveat<'r>(&mut self, predicate: &'r str) {
         let caveat: caveat::FirstPartyCaveat = caveat::new_first_party(predicate);
         self.signature = caveat.sign(&self.signature);
-        self.caveats.push(box caveat);
+        self.caveats.push(Box::new(caveat));
         debug!("Macaroon::add_first_party_caveat: {:?}", self);
     }
 
@@ -238,7 +238,7 @@ impl Macaroon {
         let vid: Vec<u8> = crypto::encrypt(self.signature, &derived_key);
         let caveat: caveat::ThirdPartyCaveat = caveat::new_third_party(id, vid, location);
         self.signature = caveat.sign(&self.signature);
-        self.caveats.push(box caveat);
+        self.caveats.push(Box::new(caveat));
         debug!("Macaroon::add_third_party_caveat: {:?}", self);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,10 +93,6 @@
 //! - verification of third-party caveats using discharge macaroons (including ones that themselves have embedded third-party caveats)
 //! - serialization and deserialization of caveats via version 1, 2 or 2J serialization formats (fully compatible with libmacaroons)
 
-#![feature(proc_macro)]
-#![feature(try_from)]
-#![feature(box_syntax, box_patterns)]
-
 #[macro_use]
 extern crate log;
 extern crate rustc_serialize as serialize;

--- a/src/serialization/v2.rs
+++ b/src/serialization/v2.rs
@@ -247,8 +247,8 @@ mod tests {
                                      238, 155, 5, 177, 88, 134, 218, 11, 168, 94, 140, 66, 169,
                                      60, 141, 14, 18, 94, 252];
         let mut builder = MacaroonBuilder::new();
-        builder.add_caveat(box caveat::new_first_party("account = 3735928559"));
-        builder.add_caveat(box caveat::new_first_party("user = alice"));
+        builder.add_caveat(Box::new(caveat::new_first_party("account = 3735928559")));
+        builder.add_caveat(Box::new(caveat::new_first_party("user = alice")));
         builder.set_location("http://example.org/");
         builder.set_identifier("keyid");
         builder.set_signature(&SIGNATURE);

--- a/src/serialization/v2j.rs
+++ b/src/serialization/v2j.rs
@@ -1,6 +1,5 @@
 use serde_json;
 use serialize::base64::{STANDARD, ToBase64, FromBase64};
-use std::convert::TryFrom;
 use std::str;
 use caveat::{CaveatBuilder, CaveatType};
 use Macaroon;
@@ -29,9 +28,9 @@ struct V2JSerialization {
     s64: Option<String>,
 }
 
-impl TryFrom<Macaroon> for V2JSerialization {
-    type Error = MacaroonError;
-    fn try_from(macaroon: Macaroon) -> Result<Self, Self::Error> {
+impl V2JSerialization {
+
+    fn from_macaroon(macaroon: Macaroon) -> Result<V2JSerialization, MacaroonError> {
         let mut serialized: V2JSerialization = V2JSerialization {
             v: 2,
             i: Some(macaroon.identifier().clone()),
@@ -75,9 +74,9 @@ impl TryFrom<Macaroon> for V2JSerialization {
     }
 }
 
-impl TryFrom<V2JSerialization> for Macaroon {
-    type Error = MacaroonError;
-    fn try_from(ser: V2JSerialization) -> Result<Self, Self::Error> {
+impl Macaroon {
+
+    fn from_v2j(ser: V2JSerialization) -> Result<Macaroon, MacaroonError> {
         if ser.i.is_some() && ser.i64.is_some() {
             return Err(MacaroonError::DeserializationError(String::from("Found i and i64 fields")));
         }
@@ -163,13 +162,13 @@ impl TryFrom<V2JSerialization> for Macaroon {
 }
 
 pub fn serialize_v2j(macaroon: &Macaroon) -> Result<Vec<u8>, MacaroonError> {
-    let serialized: String = serde_json::to_string(&V2JSerialization::try_from(macaroon.clone())?)?;
+    let serialized: String = serde_json::to_string(&V2JSerialization::from_macaroon(macaroon.clone())?)?;
     Ok(serialized.into_bytes())
 }
 
 pub fn deserialize_v2j(data: &[u8]) -> Result<Macaroon, MacaroonError> {
     let v2j: V2JSerialization = serde_json::from_slice(data)?;
-    Macaroon::try_from(v2j)
+    Macaroon::from_v2j(v2j)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This library looks interesting! But it requires nightly rust. Today this seems to boil down to `box` (vs. `Box::new()`) syntax and the `TryFrom` trait, both of which were pretty small changes to remove.

If accepted, removal of `TryFrom` breaks the external API; as this crate is still at 0.1.x and required nightly up until now, bumping to 0.2.x feels reasonable to me, but the community might have more specific norms.

I see this repo hasn't been touched in some time. cc: @tarcieri who commented somewhat recently