### PR TITLE
chore(*): Updates dependencies to their latest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: rust
 rust:
   - stable
   - nightly
-install:
-- sudo add-apt-repository -y ppa:chris-lea/libsodium
-- sudo apt-get update && sudo apt-get install libsodium-dev
 matrix:
   allow_failures:
     - rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,10 @@ license = "MIT"
 [dependencies]
 log = "0.3.6"
 rustc-serialize = "0.3.22"
-serde = "0.9.2"
-serde_derive = "0.9.2"
-serde_json = "0.9.2"
-sodiumoxide = "0.0.13"
+serde = { version= "1.0", features = ["derive"] }
+serde_json = "1.0"
+sodiumoxide = "0.2"
 
 [dev-dependencies]
-env_logger = "0.3"
+env_logger = "0.6"
 time = "0.1.36"

--- a/README.md
+++ b/README.md
@@ -42,17 +42,6 @@ The macaroon is considered authorized only if all its caveats are authorized by 
 - Creation of discharge macaroons
 - Verification of both first- and third-party caveats (the latter using discharge macaroons)
 
-## Requirements
-
-For now, you need to use the nightly build of Rust, because of `serde_derive`'s dependence on
-`#[proc_macro_derive]`, which is experimental (but should be merged into stable soon).
-
-To use the nightly compiler:
-
-```bash
-$ rustup default nightly
-```
-
 ## Usage
 In your `Cargo.toml`:
 ```

--- a/src/serialization/macaroon_builder.rs
+++ b/src/serialization/macaroon_builder.rs
@@ -7,7 +7,7 @@ pub struct MacaroonBuilder {
     identifier: String,
     location: Option<String>,
     signature: [u8; 32],
-    caveats: Vec<Box<Caveat>>,
+    caveats: Vec<Box<dyn Caveat>>,
 }
 
 impl MacaroonBuilder {
@@ -31,7 +31,7 @@ impl MacaroonBuilder {
         self.signature.clone_from_slice(signature);
     }
 
-    pub fn add_caveat(&mut self, caveat: Box<Caveat>) {
+    pub fn add_caveat(&mut self, caveat: Box<dyn Caveat>) {
         self.caveats.push(caveat);
     }
 

--- a/src/serialization/v1.rs
+++ b/src/serialization/v1.rs
@@ -84,7 +84,7 @@ fn deserialize_as_packets(data: &[u8],
     let hex: &str = str::from_utf8(&data[..4])?;
     let size: usize = usize::from_str_radix(hex, 16)?;
     let packet_data = &data[4..size];
-    let index = try!(split_index(packet_data));
+    let index = split_index(packet_data)?;
     let (key_slice, value_slice) = packet_data.split_at(index);
     packets.push(Packet {
         key: String::from_utf8(key_slice.to_vec())?,
@@ -102,10 +102,10 @@ fn split_index(packet: &[u8]) -> Result<usize, MacaroonError> {
 }
 
 pub fn deserialize_v1(base64: &[u8]) -> Result<Macaroon, MacaroonError> {
-    let data = try!(base64_decode(&String::from_utf8(base64.to_vec())?));
+    let data = base64_decode(&String::from_utf8(base64.to_vec())?)?;
     let mut builder: MacaroonBuilder = MacaroonBuilder::new();
     let mut caveat_builder: CaveatBuilder = CaveatBuilder::new();
-    for packet in try!(deserialize_as_packets(data.as_slice(), Vec::new())) {
+    for packet in deserialize_as_packets(data.as_slice(), Vec::new())? {
         match packet.key.as_str() {
             LOCATION => {
                 builder.set_location(&String::from_utf8(packet.value)?);

--- a/src/serialization/v2j.rs
+++ b/src/serialization/v2j.rs
@@ -1,5 +1,6 @@
 use serde_json;
 use serialize::base64::{STANDARD, ToBase64, FromBase64};
+use serde::{Serialize, Deserialize};
 use std::convert::TryFrom;
 use std::str;
 use caveat::{CaveatBuilder, CaveatType};

--- a/src/serialization/v2j.rs
+++ b/src/serialization/v2j.rs
@@ -1,7 +1,6 @@
 use serde_json;
 use serialize::base64::{STANDARD, ToBase64, FromBase64};
 use serde::{Serialize, Deserialize};
-use std::convert::TryFrom;
 use std::str;
 use caveat::{CaveatBuilder, CaveatType};
 use Macaroon;
@@ -30,9 +29,9 @@ struct V2JSerialization {
     s64: Option<String>,
 }
 
-impl TryFrom<Macaroon> for V2JSerialization {
-    type Error = MacaroonError;
-    fn try_from(macaroon: Macaroon) -> Result<Self, Self::Error> {
+impl V2JSerialization {
+
+    fn from_macaroon(macaroon: Macaroon) -> Result<V2JSerialization, MacaroonError> {
         let mut serialized: V2JSerialization = V2JSerialization {
             v: 2,
             i: Some(macaroon.identifier().clone()),
@@ -76,9 +75,9 @@ impl TryFrom<Macaroon> for V2JSerialization {
     }
 }
 
-impl TryFrom<V2JSerialization> for Macaroon {
-    type Error = MacaroonError;
-    fn try_from(ser: V2JSerialization) -> Result<Self, Self::Error> {
+impl Macaroon {
+
+    fn from_v2j(ser: V2JSerialization) -> Result<Macaroon, MacaroonError> {
         if ser.i.is_some() && ser.i64.is_some() {
             return Err(MacaroonError::DeserializationError(String::from("Found i and i64 fields")));
         }
@@ -164,13 +163,13 @@ impl TryFrom<V2JSerialization> for Macaroon {
 }
 
 pub fn serialize_v2j(macaroon: &Macaroon) -> Result<Vec<u8>, MacaroonError> {
-    let serialized: String = serde_json::to_string(&V2JSerialization::try_from(macaroon.clone())?)?;
+    let serialized: String = serde_json::to_string(&V2JSerialization::from_macaroon(macaroon.clone())?)?;
     Ok(serialized.into_bytes())
 }
 
 pub fn deserialize_v2j(data: &[u8]) -> Result<Macaroon, MacaroonError> {
     let v2j: V2JSerialization = serde_json::from_slice(data)?;
-    Macaroon::try_from(v2j)
+    Macaroon::from_v2j(v2j)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This also updates a few things to use the most current (read: non-deprecated) patterns
for things like `try` and removes the need for using the nightly compiler. There are no changes to actual behavior